### PR TITLE
Replace $(this).width() by $(this).css('width'

### DIFF
--- a/jquery.mosaicflow.js
+++ b/jquery.mosaicflow.js
@@ -137,7 +137,7 @@
 
 				this.columns = this.workingContainer.find('.' + this.options.columnClass);
 				this.columns.each(function(){
-					$(this).width((100 / calculatedCnt) + '%');
+					$(this).css('width',(100 / calculatedCnt) + '%');
 				});
 				return true;
 			}


### PR DESCRIPTION
I've replaced the call to 

``` javascript
    $(this).width((100 / calculatedCnt) + '%');
```

by 

``` javascript
   $(this).css('width',(100 / calculatedCnt) + '%');
```

as I've found jquery setting a greater value to the width of the element. 
I've found this when debugging why columns where bigger than needed and found out that using `css` instead of `width` fixed it.
I ignore the real cause of this, maybe a jQuery bug with `width`?
