### PR TITLE
Temporal Container never shrunk when resizing viewport.

### DIFF
--- a/jquery.mosaicflow.js
+++ b/jquery.mosaicflow.js
@@ -64,7 +64,7 @@
 			this.columns = $([]);
 			this.columnsHeights = [];
 			this.itemsHeights = {};
-			this.tempContainer = $('<div>').css({'visibility' : 'hidden', 'width' : '100%'});
+			this.tempContainer = $('<div>').css({'visibility': 'hidden', 'width': '100%'});
 			this.workOnTemp = false;
 			this.autoCalculation = this.options.itemHeightCalculation === 'auto';
 


### PR DESCRIPTION
I've found a situation where the temporal Container where all items are placed temporarily only grew but never shrunk.
To avoid this, I've forced it to be `width:100%` and don't update anymore its width.
I've tested this change with those examples in `specs` folder.
