### PR TITLE
Use svg version of Travis and Bower badges

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,7 +1,7 @@
 # Mosaic Flow
 
-[![Build Status](https://travis-ci.org/sapegin/jquery.mosaicflow.png)](https://travis-ci.org/sapegin/jquery.mosaicflow)
-[![Bower version](https://badge.fury.io/bo/jquery.mosaicflow.png)](http://badge.fury.io/bo/jquery.mosaicflow)
+[![Build Status](https://travis-ci.org/sapegin/jquery.mosaicflow.svg)](https://travis-ci.org/sapegin/jquery.mosaicflow)
+[![Bower version](https://badge.fury.io/bo/jquery.mosaicflow.svg)](http://badge.fury.io/bo/jquery.mosaicflow)
 [![Built with Grunt](https://cdn.gruntjs.com/builtwith.png)](http://gruntjs.com/)
 
 Pinterest like responsive image or HTML grid for jQuery that doesn’t suck. See [live example](http://sapegin.github.com/jquery.mosaicflow/).


### PR DESCRIPTION
Currently non svg version exists for Grunt, there is a discussion over at gruntjs.com/issues#111.